### PR TITLE
Create NuGet package

### DIFF
--- a/NewRelic.Platform.Sdk/NewRelic.Platform.Sdk.csproj
+++ b/NewRelic.Platform.Sdk/NewRelic.Platform.Sdk.csproj
@@ -76,8 +76,8 @@
   <ItemGroup>
     <None Include="App.config" />
     <None Include="config\newrelic.template.json" />
+    <None Include="NewRelic.Platform.Sdk.nuspec" />
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/NewRelic.Platform.Sdk/NewRelic.Platform.Sdk.nuspec
+++ b/NewRelic.Platform.Sdk/NewRelic.Platform.Sdk.nuspec
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>NewRelic.Platform.Sdk</id>
+    <version>1.0.0.0</version>
+    <title>New Relic Platform .NET SDK</title>
+    <authors>Adam Larson, Tom Macie, Jason Stenhouse</authors>
+    <owners>Adam Larson, Tom Macie, Jason Stenhouse</owners>
+    <licenseUrl>https://raw.github.com/newrelic-platform/newrelic_dotnet_sdk/master/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/newrelic-platform/newrelic_dotnet_sdk</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>New Relic Platform .NET SDK</description>
+    <releaseNotes>Initial release.</releaseNotes>
+    <copyright>Copyright 2013-2014</copyright>
+    <tags>NewRelic</tags>
+  </metadata>
+</package>


### PR DESCRIPTION
Add `.nuspec` metainfo file for `NewRelic.Platform.Sdk` project.
You can create NuGet package and publish it to [nuget.org](http://nuget.org/) using this [manual](http://docs.nuget.org/docs/creating-packages/creating-and-publishing-a-package).
