### PR TITLE
Updated Runner to use poll_interval from json config

### DIFF
--- a/NewRelic.Platform.Sdk/Runner.cs
+++ b/NewRelic.Platform.Sdk/Runner.cs
@@ -175,7 +175,16 @@ namespace NewRelic.Platform.Sdk
 
         private int GetPollInterval()
         {
-            int pollInterval = 60;
+            int pollInterval;
+            if (this.newRelicConfig.PollInterval.HasValue)
+            {
+                pollInterval = this.newRelicConfig.PollInterval.Value;
+            }
+            else
+            {
+                pollInterval = 60;
+            }
+
             return pollInterval *= 1000; // Convert to milliseconds since that's what system calls expect;
         }
 


### PR DESCRIPTION
The newrelic.json config file already allows you to specify a poll_interval. This pull request updates the Runner to use this value if it has been specified.
