### PR TITLE
Added Path.Combines so that this can work in Mono on Linux.

### DIFF
--- a/NewRelic.Platform.Sdk/AgentFactory.cs
+++ b/NewRelic.Platform.Sdk/AgentFactory.cs
@@ -13,7 +13,7 @@ namespace NewRelic.Platform.Sdk
     /// </summary>
     public abstract class AgentFactory
     {
-        private const string ConfigurationFilePath = @"config\plugin.json";
+        private static readonly string ConfigurationFilePath = Path.Combine("config", "plugin.json");
 
         private static Logger s_log = Logger.GetLogger("AgentFactory");
 

--- a/NewRelic.Platform.Sdk/Configuration/NewRelicConfig.cs
+++ b/NewRelic.Platform.Sdk/Configuration/NewRelicConfig.cs
@@ -9,7 +9,7 @@ namespace NewRelic.Platform.Sdk.Configuration
     public class NewRelicConfig : INewRelicConfig
     {
         private static NewRelicConfig ConfigInstance;
-        private const string ConfigPath = @"config\newrelic.json";
+        private static readonly string ConfigPath = Path.Combine("config", "newrelic.json");
         private const string DefaultEndpoint = "https://platform-api.newrelic.com/platform/v1/metrics";
         private const string DefaultLogFileName = "newrelic_plugin.log";
         private const string DefaultLogFilePath = @"logs";


### PR DESCRIPTION
I wasn't able to use the NewRelic.Platform.SDK in Mono until I fixed the pathing- there were some hard coded "\"s.

If you are interested in testing this on a Linux machine, I'm using a Docker container. It's pretty easy to setup boot2docker//docker.

https://github.com/mono/docker
