### PR TITLE
Updated config (newrelic.json) handling, resolves #41

### DIFF
--- a/NewRelic.Platform.Sdk/Configuration/NewRelicConfig.cs
+++ b/NewRelic.Platform.Sdk/Configuration/NewRelicConfig.cs
@@ -9,7 +9,6 @@ namespace NewRelic.Platform.Sdk.Configuration
     public class NewRelicConfig : INewRelicConfig
     {
         private static NewRelicConfig ConfigInstance;
-        private const string ConfigPath = @"config\newrelic.json";
         private const string DefaultEndpoint = "https://platform-api.newrelic.com/platform/v1/metrics";
         private const string DefaultLogFileName = "newrelic_plugin.log";
         private const string DefaultLogFilePath = @"logs";
@@ -68,7 +67,7 @@ namespace NewRelic.Platform.Sdk.Configuration
                 if (ConfigInstance == null)
                 {
                     string assemblyPath = Assembly.GetExecutingAssembly().GetLocalPath();
-                    string configPath = Path.Combine(assemblyPath, ConfigPath);
+                    string configPath = Path.Combine(assemblyPath, Path.Combine("config", "newrelic.json"));
 
                     if (!File.Exists(configPath))
                     {


### PR DESCRIPTION
The way how NewRelic Platform SDK is handling configuration file location is making issue if used on Linux. To make it platform agnostic, I used `Path.Combine` that was used already in the same file.

As that `private const string` is used only on one point, I converted it to be inline. 

Resolves #41 